### PR TITLE
fix method name

### DIFF
--- a/FraudManagement/get-held-transaction-list.php
+++ b/FraudManagement/get-held-transaction-list.php
@@ -47,6 +47,6 @@
   }
 
   if(!defined('DONT_RUN_SAMPLES'))
-    getHeldTransactions();
+    getHeldTransactionList();
 
 ?>


### PR DESCRIPTION
Previous name was incorrect, resulted in an error upon execution.